### PR TITLE
Use hexo.load() and query the db instead of relying on hooks and events

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,8 +7,6 @@ var config = hexo.config.algolia = assign({
 	chunkSize: 5000
 }, hexo.config.algolia);
 
-var box = hexo.source;
-
 hexo.extend.console.register('algolia', 'Index your content in Algolia Search API', {
   options: [
     {name: '-f, --fake', desc: 'Does not push content to Algolia'},

--- a/lib/command.js
+++ b/lib/command.js
@@ -1,95 +1,102 @@
 'use strict';
 
 var _ = require('lodash');
+var each = require('each-async');
 var algoliasearch = require('algoliasearch');
 var crypto = require('crypto');
 var Promise = require('bluebird');
 var log;
 
 function computeSha1(text) {
-    // change to 'md5' if you want an MD5 hash
-    var hash = crypto.createHash('sha1');
-
-    // change to 'binary' if you want a binary hash.
-    hash.setEncoding('hex');
-
-    // the text that you want to hash
-    hash.write(text);
-
-    // very important! You cannot read from the stream until you have called end()
-    hash.end();
-
-    // and now you get the resulting hash
-    return hash.read();
+  return crypto
+    .createHash('sha1')
+    .update(text, 'utf8')
+    .digest('hex');
 }
 
 
 module.exports = function (args, callback) {
+  var hexo = this;
+  var config = hexo.config;
 
-    var hexo = this;
-    var baseDir = hexo.base_dir;
-    var config = hexo.config;
-    var log = hexo.log;
-    var posts = [];
+  hexo.load()
+    .then(function() {
+      return hexo.database.model('Post')
+	.find({})
+	.filter(function(data) {
+	  return data.published;
+	})
+	.map(function(data) {
+	  var storedPost = _.pick(data, ['title', 'date', 'slug', 'content', 'excerpt', 'permalink']);
 
-    hexo.call('generate', function(err){
-        if (err) return callback(err);
-    });
+	  storedPost.objectID = computeSha1(data.path);
 
-    hexo.extend.filter.register('after_post_render', function(data){
-        if(data.published){
-            data.objectID = computeSha1(data.permalink);
-            posts.push(_.pick(data, ['title', 'slug', 'permalink', 'content', 'excerpt', 'objectID']));
-        }
-        return data;
-    });
+	  storedPost.categories = data.categories.map(function(item){
+	    return _.pick(item, ['name', 'path']);
+	  });
 
-    hexo.on('generateAfter', function(){
-        log.info('[Algolia] Identified ' + posts.length + ' posts to index.');
-        log.debug(posts);
+	  storedPost.tags = data.tags.map(function(item){
+	    return _.pick(item, ['name', 'path']);
+	  });
 
-        if(args && !args.f){
-            // Initiliaze Algolia client
-            var client = algoliasearch(config.algolia.applicationID, config.algolia.adminApiKey);
-            var index = client.initIndex(config.algolia.indexName);
+	  storedPost.author = data.author || config.author;
 
-            if(args.w){
-                indexPosts(index, posts);
-            } else {
-                log.info('[Algolia] Clearing index...');
-                index.clearIndex(function(err, content) {
-                    log.info('[Algolia] Index cleared.');
-                    indexPosts(index, posts);
-              });
-            }
+	  return storedPost;
+	});
+    })
+    .then(function(posts) {
+      hexo.log.info('[Algolia] Identified ' + posts.length + ' posts to index.');
 
-        } else {
-            log.info('[Algolia] No data sent to Algolia due to the --fake option.');
-        }
-    });
-
-    function end(err) {
-        if (err) {
-            throw err;
-        }
-
-        log.info('[Algolia] Import done.');
-    }
-
-    function indexPosts(index, posts){
-        log.info('[Algolia] Starting indexation...');
-
-        // Split our results into chunks, to get a good indexing/insert performance
-        var chunkedResults = _.chunk(posts, config.algolia.chunks);
-
-        // For each chunk of 5,000 objects, save to algolia, in parallel. Call end() when finished
-        // or if any save produces an error
-        Promise.all(chunkedResults.map(asyncSave)).then(end.bind(null, null), end);
-    }
-
-    function asyncSave (chunk) {
-      return new Promise(function() {
-        return index.saveObjects(chunk);
+      return posts.map(function toAlgoliaBatchActions(post){
+	return {
+	  action: 'updateObject',
+	  indexName: config.algolia.indexName,
+	  body: post
+	}
       });
+    })
+    .then(function(actions) {
+      // Initiliaze Algolia client
+      var client = algoliasearch(config.algolia.applicationID, config.algolia.adminApiKey);
+
+      if(args && (!args.f || !args.fake)) {
+	if(args.w || args.withoutReset){
+	  hexo.log.info('[Algolia] Skipping index reset.');
+	  indexPosts(client, actions);
+	}
+	else {
+	  hexo.log.info('[Algolia] Clearing index...');
+
+	  var index = client.initIndex(config.algolia.indexName);
+
+	  index.clearIndex(function(err, content) {
+	    hexo.log.info('[Algolia] Index cleared.');
+	    indexPosts(client, actions);
+	  });
+	}
+      }
+      else {
+	hexo.log.info('[Algolia] No data sent to Algolia due to the --fake option.');
+      }
+    });
+
+  function end(err) {
+    if (err) {
+      throw err;
     }
+
+    hexo.log.info('[Algolia] Import done.');
+  }
+
+  function indexPosts(client, posts){
+    hexo.log.info('[Algolia] Starting indexation...');
+
+    // Split our results into chunks, to get a good indexing/insert performance
+    var chunkedResults = _.chunk(posts, config.algolia.chunks);
+    var saveObjects = function saveObjects (chunks, i, next) {
+      client.batch(chunks, next);
+    };
+
+    each(chunkedResults, saveObjects, end);
+  }
 };

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/borisschapira/hexo-algolia",
   "dependencies": {
     "algoliasearch": "^3.4.0",
-    "bluebird": "^2.9.27",
+    "each-async": "^1.1.1",
     "lodash": "^4.0.0"
   }
 }


### PR DESCRIPTION
A few changes under the hood:
- rely on `hexo.load()` and `hexo.database.model('Post').find()` to fetch the content
- use `algolia.batch` to perform batch update
- use chained sha1 Node.js API
- store `post.permalink` instead of `post.path`
- remove `bluebird` dependency
- replace `async` by `each-async` (as `async.each` was the only requirement)
- handle long and short console arguments (prior to that, only the short arguments were supported)
- use `post.{tags,categories}.map` native API instead of lodash+`post.{tags,categories}.toArray()`
- remove index setting of highlighting (its layout is up to the user really, or should be behind a flag)

Works fine on my blog! (whereas it used not to work at all)

closes #5 
