### PR TITLE
Do not index page.content

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -141,9 +141,14 @@ module.exports = function(args, callback) {
               options.chunkSize
             );
 
-            return client.batch(chunk);
+            return client
+              .batch(chunk)
+              .catch(function(err){
+                hexo.log.error('[Algolia] %s', err.message);
+              });
           });
         })
+
         .then(function() {
           hexo.log.info('[Algolia] Indexing done.');
         });

--- a/lib/command.js
+++ b/lib/command.js
@@ -74,8 +74,8 @@ module.exports = function(args, callback) {
         var storedPost = _.pick(data, [
           'title',
           'date',
+          'updated',
           'slug',
-          'content',
           'excerpt',
           'permalink',
           'layout'
@@ -83,6 +83,7 @@ module.exports = function(args, callback) {
 
         storedPost.objectID = computeSha1(data.path);
         storedPost.date_as_int = Date.parse(data.date) / 1000;
+        storedPost.updated_as_int = Date.parse(data.updated) / 1000;
 
         if (data.categories) {
           storedPost.categories = data.categories.map(function(item) {


### PR DESCRIPTION
For two reasons:

1. algolia has a default size limit of 10kB for an indexed object (and it goes quicker with Chinese and Japanese)
1. title and excerpt should be where the important words are (tags are good descriptors too)

> Characters U+0800 through U+FFFF use three bytes in UTF-8, but only two in UTF-16. As a result, text in (for example) Chinese, Japanese or Devanagari will take more space in UTF-8 if there are more of these characters than there are ASCII characters.
– via https://en.wikipedia.org/wiki/UTF-8

fixes #15