### PR TITLE
Fix `--flush` flag documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Index your content in Algolia Search API
 
 Options:
   --dry-run          Does not push content to Algolia
-  --flush            Does not reset the Algolia index before starting the indexation
+  --flush            Resets the Algolia index before starting the indexation
 ```
 
 ### Security Concerns

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ hexo.extend.console.register(
       { name: '--dry-run', desc: 'Does not push content to Algolia' },
       {
         name: '--flush',
-        desc: 'Does not reset the Algolia index before starting the indexation'
+        desc: 'Resets the Algolia index before starting the indexation'
       }
     ]
   },


### PR DESCRIPTION
The `flush` will reset the index before start.

The readme and the cli argument are saying that it will NOT reset the index before starting. 